### PR TITLE
docs: improve spelling

### DIFF
--- a/src/documentation/installation.md
+++ b/src/documentation/installation.md
@@ -17,11 +17,11 @@ The button above will:
 1. Create a new repository in your own GitHub account with [Pack11ty]{.pack11ty} code
 1. Deploy a copy of this new repository to your Netlify account (you can create one during this process if you don't have one yet).
 
-Each time you push changes to your Github repository (or add/modify files directly with Github's Web interface), Netlify will build the new version of your site.
+Each time you push changes to your GitHub repository (or add/modify files directly with GitHub's Web interface), Netlify will build the new version of your site.
 
-## Creation with Pack11ty template on Github
+## Creation with Pack11ty template on GitHub
 
-If you prefer to start without Netlify hosting, create your own repository on Github from this template:
+If you prefer to start without Netlify hosting, create your own repository on GitHub from this template:
 
 [Use this template](https://github.com/nhoizey/pack11ty/generate){.github-button}{.center}
 
@@ -33,7 +33,7 @@ You need to configure a local development environment on your computer to be abl
 1. (optional) If you don't have Node.js and `npm` yet, [install Node.js](https://nodejs.org/en/)[^lts]
 1. Install [Pack11ty]{.pack11ty} dependencies with this command in your terminal: `npm install`
 
-[^clone]: You can read [cloning a repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) in Github's help.
+[^clone]: You can read [cloning a repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) in GitHub's help.
 [^lts]: The LTS (Long Time Support) version should be enough.
 
 You're ready to develop your new site and create content.

--- a/src/documentation/navigation.md
+++ b/src/documentation/navigation.md
@@ -14,11 +14,11 @@ You can even add links to other sites in the navigation by creating a file with 
 
 [^permalink]: Don't forget to also set the `permalink` to `false` to prevent Eleventy from generating an HTML file.
 
-Look at [the example linking to the project's page on Github](https://github.com/nhoizey/pack11ty/blob/master/src/github.md):
+Look at [the example linking to the project's page on GitHub](https://github.com/nhoizey/pack11ty/blob/master/src/github.md):
 
 ```yaml
 ---
-title: Github
+title: GitHub
 nav:
   order: 4
   away: https://github.com/nhoizey/pack11ty

--- a/src/github.md
+++ b/src/github.md
@@ -1,5 +1,5 @@
 ---
-title: Github
+title: GitHub
 nav:
   order: 4
 nav_away: https://github.com/nhoizey/pack11ty


### PR DESCRIPTION
- Improve text spelling of brand names
  - Change `Github` to `GitHub`