### PR TITLE
Update head.njk Comment location for Twitter CSP

### DIFF
--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -59,7 +59,7 @@
 <meta property="og:site_name" content="{{ site.title }}" />
 <meta name="twitter:creator" content="@{{ site.author.twitter }}" />
 <meta name="twitter:site" content="@{{ site.author.twitter }}" />
-{# https://dev.twitter.com/web/overview/widgets-webpage-properties#csp #}
+{# https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties#twtr-article-embedded-survey #}
 <meta name="twitter:widgets:csp" content="on" />
 {#
 https://developers.facebook.com/docs/sharing/best-practices?locale=fr_FR#images


### PR DESCRIPTION
The document has changed to https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties#twtr-article-embedded-survey